### PR TITLE
adjust implementation

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-primary.j2
@@ -1,1 +1,1 @@
-{% set mlag_ibgp_peering_ip.ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2) %}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath((switch.mlag_switch_ids.primary - 1) * 2) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/ip_addressing/mlag-ibgp-peering-ip-secondary.j2
@@ -1,1 +1,1 @@
-{% set mlag_ibgp_peering_ip.ip = vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1) %}
+{{ vrf.mlag_ibgp_peering_ipv4_pool | ansible.netcommon.ipaddr('subnet') | ansible.netcommon.ipmath(((switch.mlag_switch_ids.primary - 1) * 2) + 1) }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/router-bgp-vrfs.j2
@@ -68,14 +68,14 @@
       neighbors:
 {%                     if configure_mlag_ibgp_peering %}
 {%                         if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
-{%                             set mlag_ibgp_peering_ip = namespace() %}
 {%                             if switch.mlag_role == 'primary' %}
-{%                                 include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
+        "{% include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}":
 {%                             else %}
-{%                                 include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
+        "{% include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}":
 {%                             endif %}
+{%                         else %}
+        {{ switch.mlag_peer_l3_ip | arista.avd.default(switch.mlag_peer_ip) }}:
 {%                         endif %}
-        {{ mlag_ibgp_peering_ip.ip | arista.avd.default(switch.mlag_peer_l3_ip, switch.mlag_peer_ip) }}:
           peer_group: {{ switch.bgp_peer_groups.mlag_ipv4_underlay_peer.name }}
 {%                     endif %}
 {%                     for bgp_peer in vrf.bgp_peers %}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/network_services/vlan-interfaces.j2
@@ -136,14 +136,6 @@ vlan_interfaces:
 {%             if configure_mlag_ibgp_peering %}
 {%                 set vrf_id_int = vrf.vrf_id | arista.avd.default(vrf.vrf_vni) | int %}
 {%                 if vrf.name != 'default' %}
-{%                     if vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
-{%                         set mlag_ibgp_peering_ip = namespace() %}
-{%                         if switch.mlag_role == 'primary' %}
-{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}
-{%                         else %}
-{%                             include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}
-{%                         endif %}
-{%                     endif %}
   Vlan{{ vrf.mlag_ibgp_peering_vlan | arista.avd.default(mlag_ibgp_peering_vrfs.base_vlan + (vrf_id_int - 1)) }}:
     tenant: {{ tenant.name }}
     type: underlay_peering
@@ -152,8 +144,14 @@ vlan_interfaces:
     vrf: {{ vrf.name }}
 {%                     if underlay_rfc5549 is arista.avd.defined(true) and overlay_mlag_rfc5549 is arista.avd.defined(true) %}
     ipv6_enable: true
+{%                     elif vrf.mlag_ibgp_peering_ipv4_pool is arista.avd.defined %}
+{%                         if switch.mlag_role == 'primary' %}
+    ip_address: "{% include switch.ip_addressing.mlag_ibgp_peering_ip_primary %}/31"
+{%                         else %}
+    ip_address: "{% include switch.ip_addressing.mlag_ibgp_peering_ip_secondary %}/31"
+{%                         endif %}
 {%                     else %}
-    ip_address: {{ mlag_ibgp_peering_ip.ip | arista.avd.default(switch.mlag_l3_ip, switch.mlag_ip) }}/31
+    ip_address: {{ switch.mlag_l3_ip | arista.avd.default(switch.mlag_ip) }}/31
 {%                     endif %}
     mtu: {{ p2p_uplinks_mtu }}
 {%                 endif %}


### PR DESCRIPTION
adjust implementation to produce a single IP like all other templates and render the output directly to output yaml instead of vars.